### PR TITLE
Onboarding 누락된 기능 추가

### DIFF
--- a/app/src/main/java/com/teampatch/harmony/MainApp.kt
+++ b/app/src/main/java/com/teampatch/harmony/MainApp.kt
@@ -99,6 +99,7 @@ fun MainApp(
     ) { scaffoldPaddingValue ->
         MainNavHost(
             isFirstUser = mainUiState.isFirstUser,
+            hasGroup = mainUiState.hasGroup,
             navController = navController,
             modifier = Modifier.padding(scaffoldPaddingValue)
         )

--- a/app/src/main/java/com/teampatch/harmony/MainApp.kt
+++ b/app/src/main/java/com/teampatch/harmony/MainApp.kt
@@ -98,8 +98,7 @@ fun MainApp(
             .safeDrawingPadding()
     ) { scaffoldPaddingValue ->
         MainNavHost(
-            isFirstUser = mainUiState.isFirstUser,
-            hasGroup = mainUiState.hasGroup,
+            mainUiState = mainUiState,
             navController = navController,
             modifier = Modifier.padding(scaffoldPaddingValue)
         )

--- a/app/src/main/java/com/teampatch/harmony/MainNavHost.kt
+++ b/app/src/main/java/com/teampatch/harmony/MainNavHost.kt
@@ -64,7 +64,9 @@ fun MainNavHost(
             onStartScreenRequest = { navController.navigateToStartScreen() }
         )
 
-        addOnboardingPermissionNotificationScreen()
+        addOnboardingPermissionNotificationScreen(
+            onNextPageRequest = { navController.navigateToStartScreen() }
+        )
 
         addOnboardingStartScreen(
             onBackRequest = navController::navigateUp,

--- a/app/src/main/java/com/teampatch/harmony/MainNavHost.kt
+++ b/app/src/main/java/com/teampatch/harmony/MainNavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navOptions
 import com.teampatch.core.common.findActivity
 import com.teampatch.feature.answer.addAnswerScreen
 import com.teampatch.feature.answer.navigateToAnswerScreen
@@ -59,7 +60,16 @@ fun MainNavHost(
         /** 온보딩 */
 
         addOnboardingScreen(
-            onKakaoLoginRequest = {},
+            onHomeScreenRequest = {
+                navController.navigateToHomeScreen(
+                    navOptions = navOptions {
+                        popUpTo(HomeRoute) {
+                            inclusive = true
+                        }
+                        launchSingleTop = true
+                    }
+                )
+            },
             onPermissionNotificationRequest = { navController.navigateToPermissionNotificationScreen() },
             onStartScreenRequest = { navController.navigateToStartScreen() }
         )

--- a/app/src/main/java/com/teampatch/harmony/MainNavHost.kt
+++ b/app/src/main/java/com/teampatch/harmony/MainNavHost.kt
@@ -26,14 +26,12 @@ import com.teampatch.feature.onboarding.login.ui.addOnboardingScreen
 import com.teampatch.feature.onboarding.login.ui.addOnboardingStartScreen
 import com.teampatch.feature.onboarding.login.ui.navigateToPermissionNotificationScreen
 import com.teampatch.feature.onboarding.login.ui.navigateToStartScreen
-import com.teampatch.feature.onboarding.make.addOnboardingMakeInviteGrandParentsScreen
 import com.teampatch.feature.onboarding.make.addOnboardingMakeParentsNameScreen
 import com.teampatch.feature.onboarding.make.addOnboardingMakeProfileSettingsScreen
 import com.teampatch.feature.onboarding.make.addOnboardingMakeRelationScreen
 import com.teampatch.feature.onboarding.make.navigateToMakeGroupScreen
 import com.teampatch.feature.onboarding.make.navigateToMakeProfileSettingsScreen
 import com.teampatch.feature.onboarding.make.navigateToMakeRelationScreen
-import com.teampatch.feature.onboarding.make.navigateToShareInvitationScreen
 import com.teampatch.feature.profile.edit.addProfileEditScreen
 import com.teampatch.feature.profile.edit.navigateToProfileEditScreen
 import com.teampatch.feature.question.addQuestionScreen
@@ -78,17 +76,17 @@ fun MainNavHost(
 
         addOnboardingMakeParentsNameScreen(
             onBackRequest = navController::navigateUp,
-            onShareInvitationScreenRequest = { navController.navigateToShareInvitationScreen() }
+            onShareInvitationScreenRequest = navController::navigateToMakeRelationScreen
         )
 
-        addOnboardingMakeInviteGrandParentsScreen(
-            onBackRequest = navController::navigateUp,
-            onRelationScreenRequest = { navController.navigateToMakeRelationScreen() }
-        )
+//        addOnboardingMakeInviteGrandParentsScreen(
+//            onBackRequest = navController::navigateUp,
+//            onRelationScreenRequest = { navController.navigateToMakeRelationScreen() }
+//        )
 
         addOnboardingMakeRelationScreen(
             onBackRequest = navController::navigateUp,
-            onProfileSettingsScreenRequest = { navController.navigateToMakeProfileSettingsScreen() }
+            onProfileSettingsScreenRequest = navController::navigateToMakeProfileSettingsScreen
         )
 
         addOnboardingMakeProfileSettingsScreen(

--- a/app/src/main/java/com/teampatch/harmony/MainNavHost.kt
+++ b/app/src/main/java/com/teampatch/harmony/MainNavHost.kt
@@ -44,11 +44,11 @@ import com.teampatch.feature.question.expand.addQuestionExpandScreen
 import com.teampatch.feature.question.expand.navigateToQuestionExpandScreen
 import com.teampatch.feature.settings.addSettingsScreen
 import com.teampatch.feature.settings.navigateToSettingsScreen
+import com.teampatch.harmony.model.MainUiState
 
 @Composable
 fun MainNavHost(
-    isFirstUser: Boolean,
-    hasGroup: Boolean,
+    mainUiState: MainUiState,
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
 ) {
@@ -57,9 +57,9 @@ fun MainNavHost(
     NavHost(
         modifier = modifier,
         navController = navController,
-        startDestination = if (isFirstUser) {
+        startDestination = if (mainUiState.isFirstUser) {
             OnboardingRoute
-        } else if (!hasGroup) {
+        } else if (!mainUiState.isOnboardingComplete) {
             OnboardingStartRoute
         } else {
             HomeRoute

--- a/app/src/main/java/com/teampatch/harmony/MainNavHost.kt
+++ b/app/src/main/java/com/teampatch/harmony/MainNavHost.kt
@@ -22,6 +22,7 @@ import com.teampatch.feature.onboarding.enter.addOnboardingEnterSpaceScreen
 import com.teampatch.feature.onboarding.enter.navigateToEnterInvitationCodeScreen
 import com.teampatch.feature.onboarding.enter.navigateToEnterSpaceScreen
 import com.teampatch.feature.onboarding.login.ui.OnboardingRoute
+import com.teampatch.feature.onboarding.login.ui.OnboardingStartRoute
 import com.teampatch.feature.onboarding.login.ui.addOnboardingPermissionNotificationScreen
 import com.teampatch.feature.onboarding.login.ui.addOnboardingScreen
 import com.teampatch.feature.onboarding.login.ui.addOnboardingStartScreen
@@ -47,6 +48,7 @@ import com.teampatch.feature.settings.navigateToSettingsScreen
 @Composable
 fun MainNavHost(
     isFirstUser: Boolean,
+    hasGroup: Boolean,
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
 ) {
@@ -55,7 +57,13 @@ fun MainNavHost(
     NavHost(
         modifier = modifier,
         navController = navController,
-        startDestination = if (isFirstUser) OnboardingRoute else HomeRoute
+        startDestination = if (isFirstUser) {
+            OnboardingRoute
+        } else if (!hasGroup) {
+            OnboardingStartRoute
+        } else {
+            HomeRoute
+        }
     ) {
         /** 온보딩 */
 
@@ -63,7 +71,7 @@ fun MainNavHost(
             onHomeScreenRequest = {
                 navController.navigateToHomeScreen(
                     navOptions = navOptions {
-                        popUpTo(HomeRoute) {
+                        popUpTo(OnboardingRoute) {
                             inclusive = true
                         }
                         launchSingleTop = true

--- a/app/src/main/java/com/teampatch/harmony/MainViewModel.kt
+++ b/app/src/main/java/com/teampatch/harmony/MainViewModel.kt
@@ -27,7 +27,16 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             flowErrorCatch(
                 block = { isLoginRequiredUseCase() },
-                action = { it.printStackTrace() }
+                action = {
+                    _uiState.update { state ->
+                        state.copy(
+                            isFirstUser = true,
+                            isLoginRequired = false,
+                            isLoading = false,
+                        )
+                    }
+                    it.printStackTrace()
+                }
             )
                 .collect { isLoginRequired ->
                     _uiState.update {

--- a/app/src/main/java/com/teampatch/harmony/MainViewModel.kt
+++ b/app/src/main/java/com/teampatch/harmony/MainViewModel.kt
@@ -32,7 +32,7 @@ class MainViewModel @Inject constructor(
                         state.copy(
                             isFirstUser = true,
                             isLoginRequired = false,
-                            isLoading = false,
+                            isLoading = false
                         )
                     }
                     it.printStackTrace()

--- a/app/src/main/java/com/teampatch/harmony/MainViewModel.kt
+++ b/app/src/main/java/com/teampatch/harmony/MainViewModel.kt
@@ -39,12 +39,12 @@ class MainViewModel @Inject constructor(
                 }
             )
                 .collect { isLoginRequired ->
-                    _uiState.update {
-                        it.copy(
-                            isFirstUser = if (uiState.value.isLoading) isLoginRequired else it.isFirstUser,
+                    _uiState.update { state ->
+                        state.copy(
+                            isFirstUser = if (uiState.value.isLoading) isLoginRequired else state.isFirstUser,
                             isLoginRequired = isLoginRequired,
                             isLoading = false,
-                            hasGroup = getUserInfoUseCase().firstOrNull()?.groupId != -1
+                            isOnboardingComplete = if (isLoginRequired) false else getUserInfoUseCase().firstOrNull()?.groupId != -1
                         )
                     }
                 }

--- a/app/src/main/java/com/teampatch/harmony/MainViewModel.kt
+++ b/app/src/main/java/com/teampatch/harmony/MainViewModel.kt
@@ -4,17 +4,20 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.teampatch.core.common.flowErrorCatch
 import com.teampatch.core.domain.usecase.authentication.IsLoginRequiredUseCase
+import com.teampatch.core.domain.usecase.user.GetUserInfoUseCase
 import com.teampatch.harmony.model.MainUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val isLoginRequiredUseCase: IsLoginRequiredUseCase,
+    private val getUserInfoUseCase: GetUserInfoUseCase,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<MainUiState> = MutableStateFlow(MainUiState())
@@ -31,7 +34,8 @@ class MainViewModel @Inject constructor(
                         it.copy(
                             isFirstUser = if (uiState.value.isLoading) isLoginRequired else it.isFirstUser,
                             isLoginRequired = isLoginRequired,
-                            isLoading = false
+                            isLoading = false,
+                            hasGroup = getUserInfoUseCase().firstOrNull()?.groupId != -1
                         )
                     }
                 }

--- a/app/src/main/java/com/teampatch/harmony/model/MainUiState.kt
+++ b/app/src/main/java/com/teampatch/harmony/model/MainUiState.kt
@@ -4,4 +4,5 @@ data class MainUiState(
     val isFirstUser: Boolean = false,
     val isLoginRequired: Boolean = false,
     val isLoading: Boolean = true,
+    val hasGroup: Boolean = true,
 )

--- a/app/src/main/java/com/teampatch/harmony/model/MainUiState.kt
+++ b/app/src/main/java/com/teampatch/harmony/model/MainUiState.kt
@@ -4,5 +4,5 @@ data class MainUiState(
     val isFirstUser: Boolean = false,
     val isLoginRequired: Boolean = false,
     val isLoading: Boolean = true,
-    val hasGroup: Boolean = true,
+    val isOnboardingComplete: Boolean = true,
 )

--- a/feature/onboarding-enter/src/main/java/com/teampatch/feature/onboarding/enter/OnboardingEnterInvitationCodeScreen.kt
+++ b/feature/onboarding-enter/src/main/java/com/teampatch/feature/onboarding/enter/OnboardingEnterInvitationCodeScreen.kt
@@ -1,6 +1,8 @@
 package com.teampatch.feature.onboarding.enter
 
+import android.content.Context
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -16,14 +18,13 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
@@ -37,6 +38,11 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
 import com.teampatch.core.designsystem.component.DefaultButton
 import com.teampatch.core.designsystem.component.OnBoardingLayout
 import com.teampatch.core.designsystem.theme.BL
@@ -45,19 +51,55 @@ import com.teampatch.core.designsystem.theme.MainGreen
 import com.teampatch.feature.onboarding.enter.R.array.title_onboarding_enter_invitation
 import com.teampatch.feature.onboarding.enter.R.string.subtext_onboarding_enter_invitation
 import com.teampatch.feature.onboarding.enter.R.string.text_onboarding_enter_next
+import com.teampatch.feature.onboarding.enter.model.OnboardingEnterInvitationCodeEvent
+import com.teampatch.feature.onboarding.enter.model.OnboardingEnterInvitationCodeUiState
+import com.teampatch.feature.onboarding.enter.viewmodel.OnboardingEnterInvitationCodeViewModel
 
 private const val MAX_LENGTH = 5
+
+@Composable
+internal fun OnboardingEnterInvitationCodeRoute(
+    onBackRequest: () -> Unit,
+    onEnterSpaceScreenRequest: () -> Unit,
+    viewModel: OnboardingEnterInvitationCodeViewModel = hiltViewModel(),
+) {
+    val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
+    val context: Context = LocalContext.current
+    val uiState: OnboardingEnterInvitationCodeUiState by
+        viewModel.uiState.collectAsStateWithLifecycle()
+
+    OnboardingEnterInvitationCodeScreen(
+        onBackRequest = onBackRequest,
+        onEnterSpaceScreenRequest = { viewModel.joinGroup() },
+        onInviteCodeChange = viewModel::updateInviteCode,
+        uiState = uiState
+    )
+
+    LaunchedEffect(Unit) {
+        viewModel.onboardingEnterInvitationCodeEvent
+            .flowWithLifecycle(lifecycleOwner.lifecycle)
+            .collect { event ->
+                when (event) {
+                    is OnboardingEnterInvitationCodeEvent.Error -> {
+                        Toast.makeText(context, "초대 코드가 올바르지 않습니다.", Toast.LENGTH_LONG).show()
+                    }
+
+                    OnboardingEnterInvitationCodeEvent.Success -> {
+                        onEnterSpaceScreenRequest()
+                    }
+                }
+            }
+    }
+}
 
 @Composable
 internal fun OnboardingEnterInvitationCodeScreen(
     onBackRequest: () -> Unit,
     onEnterSpaceScreenRequest: () -> Unit,
+    onInviteCodeChange: (String) -> Unit,
+    uiState: OnboardingEnterInvitationCodeUiState,
 ) {
-    var code by remember { mutableStateOf("") }
-
-    val isCodeComplete = code.length == MAX_LENGTH
     val focusManager = LocalFocusManager.current
-
     val titles = stringArrayResource(title_onboarding_enter_invitation)
 
     OnBoardingLayout(
@@ -81,7 +123,7 @@ internal fun OnboardingEnterInvitationCodeScreen(
         bottomBar = {
             DefaultButton(
                 onClick = { onEnterSpaceScreenRequest() },
-                enabled = isCodeComplete,
+                enabled = !uiState.isProgress,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(20.dp)
@@ -112,10 +154,10 @@ internal fun OnboardingEnterInvitationCodeScreen(
                         contentAlignment = Alignment.Center
                     ) {
                         BasicTextField(
-                            value = code.getOrNull(index)?.toString() ?: "",
+                            value = uiState.inviteCode.getOrNull(index)?.toString() ?: "",
                             onValueChange = { value ->
                                 if (value.length <= 1) {
-                                    val newCode = StringBuilder(code).apply {
+                                    val newCode = StringBuilder(uiState.inviteCode).apply {
                                         if (index < length) {
                                             setCharAt(index, value.singleOrNull() ?: ' ')
                                         } else {
@@ -123,7 +165,7 @@ internal fun OnboardingEnterInvitationCodeScreen(
                                         }
                                     }.toString().trim()
 
-                                    code = newCode
+                                    onInviteCodeChange(newCode)
 
                                     if (value.isNotEmpty() && index < MAX_LENGTH - 1) {
                                         focusManager.moveFocus(FocusDirection.Next)
@@ -157,7 +199,9 @@ private fun OnboardingEnterInvitationCodeScreenPreview() {
     HarmonyTheme {
         OnboardingEnterInvitationCodeScreen(
             onBackRequest = {},
-            onEnterSpaceScreenRequest = {}
+            onEnterSpaceScreenRequest = {},
+            onInviteCodeChange = {},
+            uiState = OnboardingEnterInvitationCodeUiState()
         )
     }
 }

--- a/feature/onboarding-enter/src/main/java/com/teampatch/feature/onboarding/enter/OnboardingEnterNavigation.kt
+++ b/feature/onboarding-enter/src/main/java/com/teampatch/feature/onboarding/enter/OnboardingEnterNavigation.kt
@@ -22,7 +22,7 @@ fun NavGraphBuilder.addOnboardingEnterInvitationCodeScreen(
     onEnterSpaceScreenRequest: () -> Unit,
 ) {
     composable<OnboardingEnterInvitationCodeRoute> {
-        OnboardingEnterInvitationCodeScreen(
+        OnboardingEnterInvitationCodeRoute(
             onBackRequest = onBackRequest,
             onEnterSpaceScreenRequest = onEnterSpaceScreenRequest
         )

--- a/feature/onboarding-enter/src/main/java/com/teampatch/feature/onboarding/enter/model/OnboardingEnterInvitationCodeEvent.kt
+++ b/feature/onboarding-enter/src/main/java/com/teampatch/feature/onboarding/enter/model/OnboardingEnterInvitationCodeEvent.kt
@@ -1,0 +1,6 @@
+package com.teampatch.feature.onboarding.enter.model
+
+internal sealed interface OnboardingEnterInvitationCodeEvent {
+    data object Success : OnboardingEnterInvitationCodeEvent
+    data class Error(val t: Throwable) : OnboardingEnterInvitationCodeEvent
+}

--- a/feature/onboarding-enter/src/main/java/com/teampatch/feature/onboarding/enter/model/OnboardingEnterInvitationCodeUiState.kt
+++ b/feature/onboarding-enter/src/main/java/com/teampatch/feature/onboarding/enter/model/OnboardingEnterInvitationCodeUiState.kt
@@ -1,0 +1,6 @@
+package com.teampatch.feature.onboarding.enter.model
+
+data class OnboardingEnterInvitationCodeUiState(
+    val inviteCode: String = "",
+    val isProgress: Boolean = false,
+)

--- a/feature/onboarding-enter/src/main/java/com/teampatch/feature/onboarding/enter/viewmodel/OnboardingEnterInvitationCodeViewModel.kt
+++ b/feature/onboarding-enter/src/main/java/com/teampatch/feature/onboarding/enter/viewmodel/OnboardingEnterInvitationCodeViewModel.kt
@@ -1,0 +1,60 @@
+package com.teampatch.feature.onboarding.enter.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.teampatch.core.domain.usecase.group.JoinFamilyGroupUseCase
+import com.teampatch.feature.onboarding.enter.model.OnboardingEnterInvitationCodeEvent
+import com.teampatch.feature.onboarding.enter.model.OnboardingEnterInvitationCodeUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+internal class OnboardingEnterInvitationCodeViewModel @Inject constructor(
+    private val joinFamilyGroupUseCase: JoinFamilyGroupUseCase,
+) : ViewModel() {
+
+    private val _onboardingEnterInvitationCodeEvent: Channel<OnboardingEnterInvitationCodeEvent> =
+        Channel()
+    val onboardingEnterInvitationCodeEvent: Flow<OnboardingEnterInvitationCodeEvent> =
+        _onboardingEnterInvitationCodeEvent.receiveAsFlow()
+
+    private val _uiState: MutableStateFlow<OnboardingEnterInvitationCodeUiState> =
+        MutableStateFlow(OnboardingEnterInvitationCodeUiState())
+    val uiState: StateFlow<OnboardingEnterInvitationCodeUiState> = _uiState.asStateFlow()
+
+    fun updateInviteCode(inviteCode: String) {
+        _uiState.update { it.copy(inviteCode = inviteCode) }
+    }
+
+    fun joinGroup() {
+        if (uiState.value.isProgress) return
+        viewModelScope.launch {
+            try {
+                val inviteCode = uiState.value.inviteCode
+                require(inviteCode.toIntOrNull() != null)
+
+                _uiState.update { it.copy(isProgress = true) }
+                joinFamilyGroupUseCase(inviteCode)
+
+                _onboardingEnterInvitationCodeEvent.send(
+                    OnboardingEnterInvitationCodeEvent.Success
+                )
+            } catch (e: Exception) {
+                e.printStackTrace()
+                _onboardingEnterInvitationCodeEvent.send(
+                    OnboardingEnterInvitationCodeEvent.Error(e)
+                )
+            } finally {
+                _uiState.update { it.copy(isProgress = false) }
+            }
+        }
+    }
+}

--- a/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeNavigation.kt
+++ b/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeNavigation.kt
@@ -19,7 +19,7 @@ fun NavController.navigateToMakeGroupScreen(
 
 fun NavGraphBuilder.addOnboardingMakeParentsNameScreen(
     onBackRequest: () -> Unit,
-    onShareInvitationScreenRequest: () -> Unit,
+    onShareInvitationScreenRequest: (vipAlias: String, vipName: String) -> Unit,
 ) {
     composable<OnboardingMakeParentsNameRoute> {
         OnboardingMakeParentsNameScreen(
@@ -52,13 +52,19 @@ fun NavGraphBuilder.addOnboardingMakeInviteGrandParentsScreen(
 }
 
 @Serializable
-data object OnboardingMakeRelationRoute
+data class OnboardingMakeRelationRoute(
+    val vipAlias: String,
+    val vipName: String,
+)
 
 fun NavController.navigateToMakeRelationScreen(
+    vipAlias: String,
+    vipName: String,
     navOptions: NavOptions? = null,
     navigatorExtras: Navigator.Extras? = null,
 ) {
-    navigate(OnboardingMakeRelationRoute, navOptions, navigatorExtras)
+    val onboardingMakeRelationRoute = OnboardingMakeRelationRoute(vipAlias, vipName)
+    navigate(onboardingMakeRelationRoute, navOptions, navigatorExtras)
 }
 
 fun NavGraphBuilder.addOnboardingMakeRelationScreen(
@@ -66,7 +72,7 @@ fun NavGraphBuilder.addOnboardingMakeRelationScreen(
     onProfileSettingsScreenRequest: () -> Unit,
 ) {
     composable<OnboardingMakeRelationRoute> {
-        OnboardingMakeRelationScreen(
+        OnboardingMakeRelationRoute(
             onBackRequest = onBackRequest,
             onProfileSettingsScreenRequest = onProfileSettingsScreenRequest
         )

--- a/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeParentsNameScreen.kt
+++ b/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeParentsNameScreen.kt
@@ -43,7 +43,7 @@ import com.teampatch.feature.onboarding.make.R.string.text_onboarding_make_next
 @Composable
 internal fun OnboardingMakeParentsNameScreen(
     onBackRequest: () -> Unit,
-    onShareInvitationScreenRequest: () -> Unit,
+    onShareInvitationScreenRequest: (vipAlias: String, vipName: String) -> Unit,
 ) {
     var selectedText by rememberSaveable { mutableStateOf("") }
     var name by rememberSaveable { mutableStateOf("") }
@@ -64,7 +64,7 @@ internal fun OnboardingMakeParentsNameScreen(
         onBackRequest = { onBackRequest() },
         bottomBar = {
             DefaultButton(
-                onClick = { onShareInvitationScreenRequest() },
+                onClick = { onShareInvitationScreenRequest(selectedText, name) },
                 enabled = selectedText.isNotBlank() && name.isNotBlank(),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -162,7 +162,7 @@ private fun OnboardingMakeParentsNameScreenPreview() {
     HarmonyTheme {
         OnboardingMakeParentsNameScreen(
             onBackRequest = {},
-            onShareInvitationScreenRequest = {}
+            onShareInvitationScreenRequest = { _, _ -> }
         )
     }
 }

--- a/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeRelationScreen.kt
+++ b/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeRelationScreen.kt
@@ -78,9 +78,7 @@ internal fun OnboardingMakeRelationRoute(
                             Toast.LENGTH_LONG
                         ).show()
                     }
-
-                    is GroupMakingEvent.Init -> {}
-                    is GroupMakingEvent.Loading -> {
+                    is GroupMakingEvent.Progress -> {
                         Toast.makeText(context, "그룹 생성 중입니다. 잠시만 기다려주세요.", Toast.LENGTH_LONG).show()
                     }
                 }

--- a/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeRelationScreen.kt
+++ b/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeRelationScreen.kt
@@ -1,6 +1,8 @@
 package com.teampatch.feature.onboarding.make
 
+import android.content.Context
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -11,12 +13,14 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -26,6 +30,10 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
 import com.teampatch.core.designsystem.component.DefaultButton
 import com.teampatch.core.designsystem.component.OnBoardingLayout
 import com.teampatch.core.designsystem.theme.BL
@@ -38,14 +46,55 @@ import com.teampatch.feature.onboarding.make.R.array.title_onboarding_make_relat
 import com.teampatch.feature.onboarding.make.R.string.text_onboarding_make_grandson
 import com.teampatch.feature.onboarding.make.R.string.text_onboarding_make_name_placeholder
 import com.teampatch.feature.onboarding.make.R.string.text_onboarding_make_next
+import com.teampatch.feature.onboarding.make.model.GroupMakingEvent
+import kotlinx.coroutines.flow.collectLatest
+
+@Composable
+internal fun OnboardingMakeRelationRoute(
+    onBackRequest: () -> Unit,
+    onProfileSettingsScreenRequest: () -> Unit,
+    viewModel: OnboardingMakeRelationViewModel = hiltViewModel(),
+) {
+    val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
+    val context: Context = LocalContext.current
+
+    OnboardingMakeRelationScreen(
+        onBackRequest = onBackRequest,
+        onProfileSettingsScreenRequest = { relation: String, name: String ->
+            viewModel.createGroup(relation, name)
+        }
+    )
+
+    LaunchedEffect(Unit) {
+        viewModel.isGroupMakingEvent
+            .flowWithLifecycle(lifecycleOwner.lifecycle)
+            .collectLatest {
+                when (it) {
+                    is GroupMakingEvent.Success -> onProfileSettingsScreenRequest()
+                    is GroupMakingEvent.Error -> {
+                        Toast.makeText(
+                            context,
+                            "그룹 생성 과정에서 에러가 발생하였습니다.\n다시 시도 해주세요.",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+
+                    is GroupMakingEvent.Init -> {}
+                    is GroupMakingEvent.Loading -> {
+                        Toast.makeText(context, "그룹 생성 중입니다. 잠시만 기다려주세요.", Toast.LENGTH_LONG).show()
+                    }
+                }
+            }
+    }
+}
 
 @Composable
 internal fun OnboardingMakeRelationScreen(
     onBackRequest: () -> Unit,
-    onProfileSettingsScreenRequest: () -> Unit,
+    onProfileSettingsScreenRequest: (relation: String, name: String) -> Unit,
 ) {
-    var relation by remember { mutableStateOf("") }
-    var name by remember { mutableStateOf("") }
+    var relation by rememberSaveable { mutableStateOf("") }
+    var name by rememberSaveable { mutableStateOf("") }
 
     val titles = stringArrayResource(title_onboarding_make_relation)
 
@@ -69,7 +118,7 @@ internal fun OnboardingMakeRelationScreen(
         onBackRequest = { onBackRequest() },
         bottomBar = {
             DefaultButton(
-                onClick = { onProfileSettingsScreenRequest() },
+                onClick = { onProfileSettingsScreenRequest(relation, name) },
                 enabled = relation.isNotBlank() && name.isNotBlank(),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -115,7 +164,12 @@ fun CustomTextField(
                 value = relation,
                 onValueChange = { onRelationChange(it) },
                 enabled = true,
-                placeholder = { Text(stringResource(text_onboarding_make_grandson), color = Color.Gray) },
+                placeholder = {
+                    Text(
+                        stringResource(text_onboarding_make_grandson),
+                        color = Color.Gray
+                    )
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(G1),
@@ -140,7 +194,12 @@ fun CustomTextField(
                 value = name,
                 onValueChange = { onNameChange(it) },
                 enabled = true,
-                placeholder = { Text(stringResource(text_onboarding_make_name_placeholder), color = Color.Gray) },
+                placeholder = {
+                    Text(
+                        stringResource(text_onboarding_make_name_placeholder),
+                        color = Color.Gray
+                    )
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(G1),
@@ -160,7 +219,7 @@ private fun OnboardingMakeRelationScreenPreview() {
     HarmonyTheme {
         OnboardingMakeRelationScreen(
             onBackRequest = {},
-            onProfileSettingsScreenRequest = {}
+            onProfileSettingsScreenRequest = { _, _ -> }
         )
     }
 }

--- a/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeRelationViewModel.kt
+++ b/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeRelationViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
-class OnboardingMakeRelationViewModel @Inject constructor(
+internal class OnboardingMakeRelationViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val createFamilyGroupUseCase: CreateFamilyGroupUseCase,
 ) : ViewModel() {

--- a/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeRelationViewModel.kt
+++ b/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeRelationViewModel.kt
@@ -1,0 +1,45 @@
+package com.teampatch.feature.onboarding.make
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.teampatch.core.domain.usecase.group.CreateFamilyGroupUseCase
+import com.teampatch.feature.onboarding.make.model.GroupMakingEvent
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class OnboardingMakeRelationViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val createFamilyGroupUseCase: CreateFamilyGroupUseCase,
+) : ViewModel() {
+
+    private val onboardingMakeRelationRoute: OnboardingMakeRelationRoute =
+        savedStateHandle.toRoute<OnboardingMakeRelationRoute>()
+
+    private val _isGroupMakingEvent: MutableStateFlow<GroupMakingEvent> = MutableStateFlow(
+        GroupMakingEvent.Init
+    )
+    val isGroupMakingEvent: StateFlow<GroupMakingEvent> = _isGroupMakingEvent.asStateFlow()
+
+    fun createGroup(relation: String, name: String) {
+        if (isGroupMakingEvent.value is GroupMakingEvent.Loading) return
+
+        _isGroupMakingEvent.value = GroupMakingEvent.Loading
+
+        viewModelScope.launch {
+            try {
+                createFamilyGroupUseCase()
+                _isGroupMakingEvent.value = GroupMakingEvent.Success
+            } catch (e: Exception) {
+                e.printStackTrace()
+                _isGroupMakingEvent.value = GroupMakingEvent.Error(e)
+            }
+        }
+    }
+}

--- a/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeRelationViewModel.kt
+++ b/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeRelationViewModel.kt
@@ -8,9 +8,9 @@ import com.teampatch.core.domain.usecase.group.CreateFamilyGroupUseCase
 import com.teampatch.feature.onboarding.make.model.GroupMakingEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -22,24 +22,26 @@ class OnboardingMakeRelationViewModel @Inject constructor(
     private val onboardingMakeRelationRoute: OnboardingMakeRelationRoute =
         savedStateHandle.toRoute<OnboardingMakeRelationRoute>()
 
-    private val _isGroupMakingEvent: MutableStateFlow<GroupMakingEvent> = MutableStateFlow(
-        GroupMakingEvent.Init
-    )
-    val isGroupMakingEvent: StateFlow<GroupMakingEvent> = _isGroupMakingEvent.asStateFlow()
+    private val _isGroupMakingEvent: Channel<GroupMakingEvent> = Channel()
+    val isGroupMakingEvent: Flow<GroupMakingEvent> = _isGroupMakingEvent.receiveAsFlow()
 
-    fun createGroup(relation: String, name: String) {
-        if (isGroupMakingEvent.value is GroupMakingEvent.Loading) return
+    private var isCreatingGroup: Boolean = false
 
-        _isGroupMakingEvent.value = GroupMakingEvent.Loading
-
-        viewModelScope.launch {
-            try {
-                createFamilyGroupUseCase()
-                _isGroupMakingEvent.value = GroupMakingEvent.Success
-            } catch (e: Exception) {
-                e.printStackTrace()
-                _isGroupMakingEvent.value = GroupMakingEvent.Error(e)
+    fun createGroup(relation: String, name: String) = viewModelScope.launch {
+        try {
+            if (!isCreatingGroup) {
+                _isGroupMakingEvent.send(GroupMakingEvent.Progress)
+                return@launch
             }
+            isCreatingGroup = true
+            createFamilyGroupUseCase()
+            _isGroupMakingEvent.send(GroupMakingEvent.Success)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            _isGroupMakingEvent.send(GroupMakingEvent.Error(e))
         }
     }
+        .invokeOnCompletion {
+            isCreatingGroup = false
+        }
 }

--- a/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeViewModel.kt
+++ b/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/OnboardingMakeViewModel.kt
@@ -5,14 +5,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.teampatch.core.domain.usecase.profile.EditProfileUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 @HiltViewModel
-internal class OnboardingMakeViewModel @Inject constructor() : ViewModel() {
+internal class OnboardingMakeViewModel @Inject constructor(
+    private val editProfileUseCase: EditProfileUseCase,
+) : ViewModel() {
     var relationship by mutableStateOf("")
         private set
 
@@ -32,5 +37,14 @@ internal class OnboardingMakeViewModel @Inject constructor() : ViewModel() {
 
     fun updateProfileImage(value: Uri) {
         _profileImageUri.value = value
+    }
+
+    override fun onCleared() {
+        profileImageUri.value?.let {
+            viewModelScope.launch {
+                editProfileUseCase(null, it.toString())
+            }
+        }
+        super.onCleared()
     }
 }

--- a/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/model/GroupMakingEvent.kt
+++ b/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/model/GroupMakingEvent.kt
@@ -3,6 +3,5 @@ package com.teampatch.feature.onboarding.make.model
 sealed interface GroupMakingEvent {
     data object Success : GroupMakingEvent
     data class Error(val t: Throwable) : GroupMakingEvent
-    data object Init : GroupMakingEvent
-    data object Loading : GroupMakingEvent
+    data object Progress : GroupMakingEvent
 }

--- a/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/model/GroupMakingEvent.kt
+++ b/feature/onboarding-make/src/main/java/com/teampatch/feature/onboarding/make/model/GroupMakingEvent.kt
@@ -1,0 +1,8 @@
+package com.teampatch.feature.onboarding.make.model
+
+sealed interface GroupMakingEvent {
+    data object Success : GroupMakingEvent
+    data class Error(val t: Throwable) : GroupMakingEvent
+    data object Init : GroupMakingEvent
+    data object Loading : GroupMakingEvent
+}

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/model/LoginEvent.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/model/LoginEvent.kt
@@ -1,0 +1,7 @@
+package com.teampatch.feature.onboarding.login.model
+
+internal sealed interface LoginEvent {
+    data object Success : LoginEvent
+    data object FamilyRegistrationRequired : LoginEvent
+    data class Error(val t: Throwable) : LoginEvent
+}

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingFirstScreen.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingFirstScreen.kt
@@ -32,10 +32,11 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.teampatch.core.designsystem.R
+import com.teampatch.feature.onboarding.login.model.LoginEvent
 
 @Composable
 internal fun OnboardingFirstScreen(
-    onKakaoLoginRequest: () -> Unit,
+    onHomeScreenRequest: () -> Unit,
     onPermissionNotificationRequest: () -> Unit,
     onStartScreenRequest: () -> Unit,
     viewModel: OnboardingViewModel = hiltViewModel(),
@@ -52,15 +53,21 @@ internal fun OnboardingFirstScreen(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.loginSuccessEvent.collect { isLoginSuccessful ->
-            if (isLoginSuccessful) {
-                if (!hasNotificationGranted(context)) {
-                    onPermissionNotificationRequest()
-                } else {
-                    onStartScreenRequest()
+        viewModel.loginEvent.collect { event ->
+            when (event) {
+                is LoginEvent.Error -> {
+                    Toast.makeText(context, "로그인에 실패했습니다.", Toast.LENGTH_LONG).show()
                 }
-            } else {
-                Toast.makeText(context, "로그인에 실패했습니다.", Toast.LENGTH_SHORT).show()
+                LoginEvent.FamilyRegistrationRequired -> {
+                    if (!hasNotificationGranted(context)) {
+                        onPermissionNotificationRequest()
+                    } else {
+                        onStartScreenRequest()
+                    }
+                }
+                LoginEvent.Success -> {
+                    onHomeScreenRequest()
+                }
             }
         }
     }
@@ -112,7 +119,7 @@ internal fun OnboardingFirstScreen(
 @Composable
 fun OnboardingLoginScreenPreview() {
     OnboardingFirstScreen(
-        onKakaoLoginRequest = {},
+        onHomeScreenRequest = {},
         onPermissionNotificationRequest = {},
         onStartScreenRequest = {}
     )

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingFirstScreen.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingFirstScreen.kt
@@ -67,7 +67,25 @@ internal fun OnboardingFirstScreen(
 
     Scaffold(
         modifier = Modifier
-            .fillMaxSize()
+            .fillMaxSize(),
+        bottomBar = {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .height(68.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .clickable { viewModel.loginKakao() },
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.kakao_login_medium_wide),
+                    contentDescription = "Kakao Login",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Fit
+                )
+            }
+        }
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -86,23 +104,6 @@ internal fun OnboardingFirstScreen(
             )
 
             Spacer(modifier = Modifier.height(465.dp))
-
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp)
-                    .height(68.dp)
-                    .clip(RoundedCornerShape(10.dp))
-                    .clickable { viewModel.loginKakao() },
-                contentAlignment = Alignment.Center
-            ) {
-                Image(
-                    painter = painterResource(id = R.drawable.kakao_login_medium_wide),
-                    contentDescription = "Kakao Login",
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Fit
-                )
-            }
         }
     }
 }

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingNavigation.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingNavigation.kt
@@ -46,9 +46,11 @@ fun NavController.navigateToPermissionNotificationScreen(
     navigate(OnboardingPermissionRoute, navOptions, navigatorExtras)
 }
 
-fun NavGraphBuilder.addOnboardingPermissionNotificationScreen() {
+fun NavGraphBuilder.addOnboardingPermissionNotificationScreen(
+    onNextPageRequest: () -> Unit
+) {
     composable<OnboardingPermissionRoute> {
-        OnboardingPermissionNotificationScreen()
+        OnboardingPermissionNotificationScreen(onNextPageRequest = onNextPageRequest)
     }
 }
 

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingNavigation.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingNavigation.kt
@@ -23,13 +23,13 @@ fun NavController.navigateToOnboardingScreen(
 }
 
 fun NavGraphBuilder.addOnboardingScreen(
-    onKakaoLoginRequest: () -> Unit,
+    onHomeScreenRequest: () -> Unit,
     onPermissionNotificationRequest: () -> Unit,
     onStartScreenRequest: () -> Unit,
 ) {
     composable<OnboardingRoute> {
         OnboardingRoute(
-            onKakaoLoginRequest = onKakaoLoginRequest,
+            onHomeScreenRequest = onHomeScreenRequest,
             onPermissionNotificationRequest = onPermissionNotificationRequest,
             onStartScreenRequest = onStartScreenRequest
         )
@@ -47,7 +47,7 @@ fun NavController.navigateToPermissionNotificationScreen(
 }
 
 fun NavGraphBuilder.addOnboardingPermissionNotificationScreen(
-    onNextPageRequest: () -> Unit
+    onNextPageRequest: () -> Unit,
 ) {
     composable<OnboardingPermissionRoute> {
         OnboardingPermissionNotificationScreen(onNextPageRequest = onNextPageRequest)

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingPermissionNotificationScreen.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingPermissionNotificationScreen.kt
@@ -1,7 +1,6 @@
 package com.teampatch.feature.onboarding.login.ui
 
 import android.app.Activity
-import android.content.pm.PackageManager
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -34,7 +33,9 @@ private val requiredPermissions: Array<String> = arrayOf(
 )
 
 @Composable
-fun OnboardingPermissionNotificationScreen() {
+fun OnboardingPermissionNotificationScreen(
+    onNextPageRequest: () -> Unit
+) {
     val context = LocalContext.current
     Scaffold(
         bottomBar = {
@@ -101,5 +102,5 @@ fun OnboardingPermissionNotificationScreen() {
 @Preview(showBackground = true)
 @Composable
 fun OnboardingPermissionNotificationScreenPreview() {
-    OnboardingPermissionNotificationScreen()
+    OnboardingPermissionNotificationScreen({})
 }

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingPermissionNotificationScreen.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingPermissionNotificationScreen.kt
@@ -1,6 +1,8 @@
 package com.teampatch.feature.onboarding.login.ui
 
 import android.app.Activity
+import android.content.pm.PackageManager
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +29,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.teampatch.core.designsystem.R
 
+private val requiredPermissions: Array<String> = arrayOf(
+    android.Manifest.permission.POST_NOTIFICATIONS
+)
+
 @Composable
 fun OnboardingPermissionNotificationScreen() {
     val context = LocalContext.current
@@ -34,12 +40,9 @@ fun OnboardingPermissionNotificationScreen() {
         bottomBar = {
             Button(
                 onClick = {
-                    (context as? Activity)?.requestPermissions(
-                        arrayOf(
-                            android.Manifest.permission.POST_NOTIFICATIONS
-                        ),
-                        1
-                    )
+                    (context as? Activity)
+                        ?.requestPermissions(requiredPermissions, 1)
+                    onNextPageRequest()
                 },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingPermissionNotificationScreen.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingPermissionNotificationScreen.kt
@@ -1,7 +1,6 @@
 package com.teampatch.feature.onboarding.login.ui
 
 import android.app.Activity
-import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -34,7 +33,7 @@ private val requiredPermissions: Array<String> = arrayOf(
 
 @Composable
 fun OnboardingPermissionNotificationScreen(
-    onNextPageRequest: () -> Unit
+    onNextPageRequest: () -> Unit,
 ) {
     val context = LocalContext.current
     Scaffold(

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingPermissionNotificationScreen.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingPermissionNotificationScreen.kt
@@ -31,6 +31,33 @@ import com.teampatch.core.designsystem.R
 fun OnboardingPermissionNotificationScreen() {
     val context = LocalContext.current
     Scaffold(
+        bottomBar = {
+            Button(
+                onClick = {
+                    (context as? Activity)?.requestPermissions(
+                        arrayOf(
+                            android.Manifest.permission.POST_NOTIFICATIONS
+                        ),
+                        1
+                    )
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 12.dp)
+                    .height(68.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent), // 투명한 배경
+                contentPadding = PaddingValues(0.dp), // 버튼의 기본 내부 패딩 제거
+                shape = RoundedCornerShape(10.dp)
+            ) {
+                // 이미지 리소스를 painterResource로 불러오고 버튼을 꽉 채움
+                Image(
+                    painter = painterResource(id = R.drawable.btn_start_harmony), // 카카오 로그인 이미지
+                    contentDescription = "Harmoy Start Process",
+                    modifier = Modifier.fillMaxSize(), // 이미지가 버튼의 크기를 꽉 채움
+                    contentScale = ContentScale.Crop // 이미지가 버튼 크기에 맞춰 잘림
+                )
+            }
+        },
         modifier = Modifier
             .fillMaxSize()
             .background(Color(0xFFF5F5F5))
@@ -63,34 +90,6 @@ fun OnboardingPermissionNotificationScreen() {
                     modifier = Modifier
                         .fillMaxWidth()
                 )
-
-                Spacer(modifier = Modifier.height(36.dp))
-
-                Button(
-                    onClick = {
-                        (context as? Activity)?.requestPermissions(
-                            arrayOf(
-                                android.Manifest.permission.POST_NOTIFICATIONS
-                            ),
-                            1
-                        )
-                    },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 20.dp)
-                        .height(68.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent), // 투명한 배경
-                    contentPadding = PaddingValues(0.dp), // 버튼의 기본 내부 패딩 제거
-                    shape = RoundedCornerShape(10.dp)
-                ) {
-                    // 이미지 리소스를 painterResource로 불러오고 버튼을 꽉 채움
-                    Image(
-                        painter = painterResource(id = R.drawable.btn_start_harmony), // 카카오 로그인 이미지
-                        contentDescription = "Harmoy Start Process",
-                        modifier = Modifier.fillMaxSize(), // 이미지가 버튼의 크기를 꽉 채움
-                        contentScale = ContentScale.Crop // 이미지가 버튼 크기에 맞춰 잘림
-                    )
-                }
             }
         }
     }

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingRoute.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingRoute.kt
@@ -4,12 +4,12 @@ import androidx.compose.runtime.Composable
 
 @Composable
 internal fun OnboardingRoute(
-    onKakaoLoginRequest: () -> Unit,
+    onHomeScreenRequest: () -> Unit,
     onPermissionNotificationRequest: () -> Unit,
     onStartScreenRequest: () -> Unit,
 ) {
     OnboardingFirstScreen(
-        onKakaoLoginRequest = onKakaoLoginRequest,
+        onHomeScreenRequest = onHomeScreenRequest,
         onPermissionNotificationRequest = onPermissionNotificationRequest,
         onStartScreenRequest = onStartScreenRequest
     )

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.liveData
 import androidx.lifecycle.viewModelScope
+import com.teampatch.core.domain.exception.FamilyRegistrationRequiredException
 import com.teampatch.core.domain.model.Host
 import com.teampatch.core.domain.model.Image
 import com.teampatch.core.domain.model.InvitationMessage
@@ -32,8 +33,14 @@ internal class OnboardingViewModel @Inject constructor(
                 loginKakaoUseCase()
             }.onSuccess {
                 _loginSuccessEvent.send(true)
-            }.onFailure {
+            }.onFailure { t ->
+                if (t is FamilyRegistrationRequiredException) {
+                    _loginSuccessEvent.send(true)
+                    return@launch
+                }
+
                 _loginSuccessEvent.send(false)
+                t.printStackTrace()
             }
         }
     }

--- a/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/com/teampatch/feature/onboarding/login/ui/OnboardingViewModel.kt
@@ -9,39 +9,37 @@ import com.teampatch.core.domain.model.Host
 import com.teampatch.core.domain.model.Image
 import com.teampatch.core.domain.model.InvitationMessage
 import com.teampatch.core.domain.usecase.onboarding.LoginKakaoUseCase
-import com.teampatch.core.domain.usecase.onboarding.LoginUseCase
 import com.teampatch.core.domain.usecase.onboarding.RegisterFamilyUseCase
+import com.teampatch.feature.onboarding.login.model.LoginEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
 internal class OnboardingViewModel @Inject constructor(
     private val loginKakaoUseCase: LoginKakaoUseCase,
-    private val loginUseCase: LoginUseCase, // 이것도 언젠간 쓰여야할 것 같은데..
     private val registerFamilyUseCase: RegisterFamilyUseCase,
 ) : ViewModel() {
 
-    private val _loginSuccessEvent = Channel<Boolean>()
-    val loginSuccessEvent = _loginSuccessEvent.receiveAsFlow()
+    private val _loginEvent: Channel<LoginEvent> = Channel()
+    val loginEvent: Flow<LoginEvent> = _loginEvent.receiveAsFlow()
 
-    fun loginKakao() {
-        viewModelScope.launch {
-            runCatching {
-                loginKakaoUseCase()
-            }.onSuccess {
-                _loginSuccessEvent.send(true)
-            }.onFailure { t ->
-                if (t is FamilyRegistrationRequiredException) {
-                    _loginSuccessEvent.send(true)
-                    return@launch
-                }
-
-                _loginSuccessEvent.send(false)
-                t.printStackTrace()
+    fun loginKakao() = viewModelScope.launch {
+        runCatching {
+            loginKakaoUseCase()
+        }.onSuccess {
+            _loginEvent.send(LoginEvent.Success)
+        }.onFailure { t ->
+            if (t is FamilyRegistrationRequiredException) {
+                _loginEvent.send(LoginEvent.FamilyRegistrationRequired)
+                return@launch
             }
+
+            _loginEvent.send(LoginEvent.Error(t))
+            t.printStackTrace()
         }
     }
 


### PR DESCRIPTION
## 🤷‍♂️ Description
- [x] 카카오 로그인이 정상작동하는지 확인합니다
- [x] 온보딩 화면 순서가 맞는지 체크합니다.
- [x] 그룹 생성이 정상적으로 작동하는지 체크합니다.
- [x] 그룹 가입이 정상적으로 작동하는지 체크합니다.
- [x] 프로필 수정이 정상적으로 작동하는지 체크합니다.
- [x] 알림 권한 체크 화면에서 정상 장독하는지 체크합니다.
- [x] 온보딩 중간에 앱 종료 후 앱 재시작시 온보딩 화면을 다시 불러오도록 합니다.
- [ ] 로그인 완료후 화면이동이 부자연스러운 부분을 수정합니다.

## 🔄 How to reproduce bug
- 어떻게 해결하였는지 간략하게 설명합니다.

## 📸 Screenshots
- 필요한 경우 사진을 남깁니다.

## ✳️Remarks
- addOnboardingMakeInviteGrandParentsScreen 해당화면은 기획이 명확하지 않아 주석처리 하였습니다 추후에 수정하도록 하겠습니다.
- 프로필 업로드가 ViewModel onCleared가 될때 API 호출되는데 그부분이 사실 무서운데 그부분 제외하면 문제 없습니다